### PR TITLE
update runVst.R set log base to 2

### DIFF
--- a/R/runVst.R
+++ b/R/runVst.R
@@ -49,7 +49,7 @@ runVst <- function(scCNA,
         varbin_counts_df[varbin_counts_df == 0] <- 1e-4
         counts_df_ft <- as.data.frame(apply(varbin_counts_df,
                                             2,
-                                            function(x) log(x)))
+                                            function(x) log(x, base = 2)))
     }
 
     counts_df_ft <- as.data.frame(counts_df_ft)


### PR DESCRIPTION
The log option in runVst applied a natural log however runSegmentation() convert it back using 2^n. This change make the log option in runVst apply log2() transform.